### PR TITLE
Add launcher example

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.7-nightly'
+          - '1.7'
+          - '1.8'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
+          # - macOS-latest
         arch:
           - x64
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-ForeignCallbacks = "809b5ff2-8730-47bb-8e19-67299d747c44"
 PMIx_jll = "32165bc3-0280-59bc-8c0b-c33b6203efab"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
@@ -13,4 +12,3 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 CEnum = "0.4"
 PMIx_jll = "4"
 Setfield = "0.8"
-ForeignCallbacks = "0.1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.1.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+ForeignCallbacks = "809b5ff2-8730-47bb-8e19-67299d747c44"
 PMIx_jll = "32165bc3-0280-59bc-8c0b-c33b6203efab"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
 [compat]
 CEnum = "0.4"
-Setfield = "0.8"
 PMIx_jll = "4"
+Setfield = "0.8"
+ForeignCallbacks = "0.1"

--- a/examples/dynamic.jl
+++ b/examples/dynamic.jl
@@ -31,7 +31,7 @@ function main()
                 cmd.exec,
                 String[],
                 pwd(),
-                2,
+                1,
                 PMIx.API.pmix_info_t[],
             )
         ]
@@ -48,7 +48,7 @@ function main()
         @info "Client: Foreign job size" ns=nspace(myproc) rank = myproc.rank nprocs_foreign
 
         # get a proc-specific value
-        tmp = let proc = PMIx.Proc(nspace_foreign, 1)
+        tmp = let proc = PMIx.Proc(nspace_foreign, 0)
             value = PMIx.get(proc, PMIx.API.PMIX_LOCAL_RANK)
             PMIx.get_number(value)
         end

--- a/examples/dynamic.jl
+++ b/examples/dynamic.jl
@@ -1,0 +1,69 @@
+# Based off https://github.com/openpmix/openpmix/blob/4d07260d9f79bb7f328b1fc9107b45e683cf2c4e/examples/dynamic.c
+using PMIx
+
+import PMIx: nspace
+
+function main()
+    myproc = PMIx.init()
+    @info "Client running" ns=nspace(myproc) rank=myproc.rank
+
+
+    # get our job size
+    nprocs = let proc = PMIx.Proc(myproc.nspace, PMIx.API.PMIX_RANK_WILDCARD)
+        value = PMIx.get(proc, PMIx.API.PMIX_JOB_SIZE)
+        PMIx.get_number(value)
+    end
+
+    @info "Client" ns=nspace(myproc) rank=myproc.rank nprocs
+
+    # call fence to sync
+    let proc = PMIx.Proc(myproc.nspace, PMIx.API.PMIX_RANK_WILDCARD)
+        PMIx.fence(proc)
+    end
+
+    # rank 0 calls spawn
+    if myproc.rank == 0
+        client = joinpath(@__DIR__, "client.jl")
+        cmd = `$(Base.julia_cmd()) $client`
+        apps = [
+            PMIx.App(
+                first(cmd.exec),
+                cmd.exec,
+                String[],
+                pwd(),
+                2,
+                PMIx.API.pmix_info_t[],
+            )
+        ]
+
+        # spawn the application
+        nspace_foreign = PMIx.spawn(apps)
+        @info "Spawned in" nspace_foreign rank = myproc.rank
+
+        # get their universe size
+        nprocs_foreign = let proc = PMIx.Proc(nspace_foreign, PMIx.API.PMIX_RANK_WILDCARD)
+            value = PMIx.get(proc, PMIx.API.PMIX_JOB_SIZE)
+            PMIx.get_number(value)
+        end
+        @info "Client: Foreign job size" ns=nspace(myproc) rank = myproc.rank nprocs_foreign
+
+        # get a proc-specific value
+        tmp = let proc = PMIx.Proc(nspace_foreign, 1)
+            value = PMIx.get(proc, PMIx.API.PMIX_LOCAL_RANK)
+            PMIx.get_number(value)
+        end
+        @info "Client: Local rank" ns=nspace(myproc) rank = myproc.rank lrank=tmp
+
+    end
+
+    # call fence to sync
+    let proc = PMIx.Proc(myproc.nspace, PMIx.API.PMIX_RANK_WILDCARD)
+        PMIx.fence(proc)
+    end
+    PMIx.finalize()
+    exit()
+end
+
+if !isinteractive()
+    main()
+end

--- a/examples/launcher.jl
+++ b/examples/launcher.jl
@@ -1,0 +1,47 @@
+# Based off https://github.com/openpmix/openpmix/blob/4d07260d9f79bb7f328b1fc9107b45e683cf2c4e/examples/launcher.c
+using PMIx
+
+function main()
+    # we need to attach to a "system" PMIx server so we
+    # can ask it to spawn applications for us. There can
+    # only be one such connection on a node, so we will
+    # instruct the tool library to only look for it
+
+    info = PMIx.Info(PMIx.API.PMIX_CONNECT_TO_SYSTEM, PMIx.Value(true, PMIx.API.PMIX_BOOL))
+    myproc = PMIx.tool_init(Ref(info))
+
+    # TODO event handler
+
+    # provide directives so the apps do what the user requested - just
+    # some random examples provided here
+
+    infos = [
+        PMIx.Info(PMIx.API.PMIX_MAPBY, PMIx.Value("slot", PMIx.API.PMIX_STRING))
+        PMIx.Info(PMIx.API.PMIX_NOTIFY_COMPLETION, PMIx.Value(true, PMIx.API.PMIX_BOOL))
+    ]
+
+    # parse the cmd line and create our array of app structs
+    # describing the application we want launched
+    # can also provide environmental params in the app.env field
+    cmd = `$(Base.julia_cmd()) --eval "exit()"`
+    apps = [
+        PMIx.App(
+            first(cmd.exec),
+            cmd.exec,
+            String[],
+            pwd(),
+            2,
+            infos,
+        )
+    ]
+
+    # spawn the application
+    nspace = PMIx.spawn(apps)
+    @info "Spawned in" nspace
+
+    PMIx.tool_finalize()
+end
+
+if !isinteractive()
+    main()
+end

--- a/examples/launcher.jl
+++ b/examples/launcher.jl
@@ -8,7 +8,7 @@ function main()
     # instruct the tool library to only look for it
 
     info = PMIx.Info(PMIx.API.PMIX_CONNECT_TO_SYSTEM, PMIx.Value(true, PMIx.API.PMIX_BOOL))
-    myproc = PMIx.tool_init(Ref(info))
+    _ = PMIx.tool_init(Ref(info))
 
     # TODO event handler
 

--- a/res/prologue.jl
+++ b/res/prologue.jl
@@ -9,6 +9,8 @@ function __init__()
 end
 
 const pid_t = Cint
+const gid_t = Cuint
+const uid_t = Cuint
 
 const __time_t = Clong
 const __suseconds_t = Clong

--- a/res/wrap.jl
+++ b/res/wrap.jl
@@ -8,9 +8,11 @@ options = load_options(joinpath(@__DIR__, "wrap.toml"))
 args = get_default_args()
 push!(args, "-I$include_dir")
 
-headers = [joinpath(include_dir, header) for header in ["pmix.h"]]
+headers = [joinpath(include_dir, header) for header in ["pmix.h", "pmix_tool.h", "pmix_server.h"]]
 
 @add_def pid_t
+@add_def gid_t
+@add_def uid_t
 @add_def __time_t
 @add_def __suseconds_t
 @add_def time_t

--- a/src/PMIx.jl
+++ b/src/PMIx.jl
@@ -7,6 +7,12 @@ struct PMIxException <: Exception
     status::API.pmix_status_t
 end
 
+function Base.showerror(io::IO, pmi::PMIxException)
+    print(io, "PMIxException: ")
+    print(io, unsafe_string(API.PMIx_Error_string(pmi.status)))
+end
+
+
 macro check(ex)
     quote
         status = $(esc(ex))

--- a/src/PMIx.jl
+++ b/src/PMIx.jl
@@ -195,13 +195,17 @@ function Base.cconvert(::Type{API.pmix_app_t}, app::App)
 end
 
 function Base.unsafe_convert(::Type{API.pmix_app_t}, app::CApp)
+    argv = isempty(app.argv) ? C_NULL : Base.unsafe_convert(Ptr{Ptr{Cchar}}, app.argv)
+    env = isempty(app.env) ? C_NULL : Base.unsafe_convert(Ptr{Ptr{Cchar}}, app.env)
+    info = isempty(app.app.info) ? C_NULL : Base.unsafe_convert(Ptr{API.pmix_info_t}, app.app.info)
+
     API.pmix_app_t(
         Base.unsafe_convert(Ptr{Cchar}, app.app.cmd),
-        Base.unsafe_convert(Ptr{Ptr{Cchar}}, app.argv),
-        Base.unsafe_convert(Ptr{Ptr{Cchar}}, app.env),
+        argv,
+        env,
         Base.unsafe_convert(Ptr{Cchar}, app.app.cwd),
         app.app.maxprocs,
-        Base.unsafe_convert(Ptr{API.pmix_info_t}, app.app.info),
+        info,
         length(app.app.info)
     )
 end

--- a/src/PMIx.jl
+++ b/src/PMIx.jl
@@ -1,5 +1,6 @@
 module PMIx
-using  Setfield
+using Setfield
+using ForeignCallbacks
 
 include("api.jl")
 

--- a/src/PMIx.jl
+++ b/src/PMIx.jl
@@ -47,8 +47,7 @@ end
 function Info(key, value, flags = 0)
     r_key = Ref{API.pmix_key_t}()
     GC.@preserve r_key key begin
-        cstr = Base.unsafe_convert(Cstring, key) # ensure null termination
-        p_src = convert(Ptr{Cchar}, cstr)
+        p_src = Base.unsafe_convert(Ptr{Cchar}, key)
         p_dst = Base.unsafe_convert(Ptr{Cchar}, r_key)
         pmix_strncopy(p_dst, p_src, API.PMIX_MAX_KEYLEN)
     end
@@ -114,7 +113,7 @@ function get(proc, key, info=nothing)
         info = C_NULL
         len = 0
     else 
-        len= length(info)
+        len = length(info)
     end
     r_ptr = Ref{Ptr{API.pmix_value_t}}()
     @check API.PMIx_Get(Ref(proc), key, info, len, r_ptr)

--- a/src/PMIx.jl
+++ b/src/PMIx.jl
@@ -121,8 +121,14 @@ function progress()
 end
 
 # 5. Synchronization and Data Access Operations
-
-function fence(procs)
+fence(proc::API.pmix_proc_t, info=nothing) = fence(Ref(proc), info)
+function fence(procs, info=nothing)
+    if info === nothing
+        info = C_NULL
+        len = 0
+    else
+        len = length(info)
+    end
     @check API.PMIx_Fence(procs, length(procs), C_NULL, 0)
 end
 

--- a/src/PMIx.jl
+++ b/src/PMIx.jl
@@ -85,10 +85,15 @@ function version()
     return Base.unsafe_string(API.PMIx_Get_version())
 end
 
-# TODO: Parameters
-function init()
+function init(info=nothing)
+    if info === nothing
+        info = C_NULL
+        len = 0
+    else
+        len = lenght(info)
+    end
     r_proc = Ref{API.pmix_proc_t}()
-    @check API.PMIx_Init(r_proc, C_NULL, 0)
+    @check API.PMIx_Init(r_proc, info, len)
     return r_proc[]
 end
 

--- a/src/PMIx.jl
+++ b/src/PMIx.jl
@@ -1,6 +1,5 @@
 module PMIx
 using Setfield
-using ForeignCallbacks
 
 include("api.jl")
 

--- a/src/value.jl
+++ b/src/value.jl
@@ -53,6 +53,12 @@ function Value(data::String, type)
     end
 end
 
+function Value(data::Ptr{Cvoid}, type)
+    value = ZeroValue()
+    value = load(value, data, type)
+    return value
+end
+
 # function xfer()
 # end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,9 @@ end
 
     optional = PMIx.Value(false, PMIx.API.PMIX_BOOL)
     @test !convert(Bool, optional)
+
+    str = PMIx.Value("hello", PMIx.API.PMIX_STRING)
+    @test convert(String, str) == "hello"
 end
 
 @testset "Job size" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,6 +72,10 @@ end
 
     str = PMIx.Value("hello", PMIx.API.PMIX_STRING)
     @test convert(String, str) == "hello"
+
+    ptr = PMIx.Value(C_NULL, PMIx.API.PMIX_STRING)
+    @test convert(Ptr{Cvoid}, ptr) == C_NULL
+    @test Base.unsafe_convert(Ptr{Cvoid}, ptr) == C_NULL
 end
 
 @testset "Job size" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,10 +10,20 @@ if !haskey(ENV, "PRTE_LAUNCHED")
     end
 
     @testset "Examples" begin
-        example = realpath(joinpath(@__DIR__, "..", "examples", "client.jl"))
-        prrte_jll.prterun() do prterun
-            cmd = `$prterun -np 2 $(Base.julia_cmd()) $example`
-            @test success(pipeline(cmd, stdout=stdout, stderr=stderr))
+        for file in ["client.jl",]
+            example = realpath(joinpath(@__DIR__, "..", "examples", file))
+            prrte_jll.prterun() do prterun
+                cmd = `$prterun -np 2 $(Base.julia_cmd()) $example`
+                @test success(pipeline(cmd, stdout=stdout, stderr=stderr))
+            end
+        end
+
+        for file in ["launcher.jl"]
+            example = realpath(joinpath(@__DIR__, "..", "examples", file))
+            prrte_jll.prterun() do prterun
+                cmd = `$prterun -np 1 $(Base.julia_cmd()) $example`
+                @test success(pipeline(cmd, stdout=stdout, stderr=stderr))
+            end
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ if !haskey(ENV, "PRTE_LAUNCHED")
             end
         end
 
-        for file in ["launcher.jl"]
+        for file in ["launcher.jl", "dynamic.jl"]
             example = realpath(joinpath(@__DIR__, "..", "examples", file))
             prrte_jll.prterun() do prterun
                 cmd = `$prterun -np 1 $(Base.julia_cmd()) $example`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,11 +16,9 @@ if !haskey(ENV, "PRTE_LAUNCHED")
         ]
         for (file, np) in examples
             example = realpath(joinpath(@__DIR__, "..", "examples", file))
-            prrte_jll.prterun() do prterun
-                cmd = `$prterun -np $np $(Base.julia_cmd()) $example`
-                @testset "Example $file" begin
-                    @test success(pipeline(cmd, stdout=stdout, stderr=stderr))
-                end
+            cmd = `$(prterun()) -np $np $(Base.julia_cmd()) $example`
+            @testset "Example $file" begin
+                @test success(pipeline(cmd, stdout=stdout, stderr=stderr))
             end
         end
 
@@ -28,9 +26,7 @@ if !haskey(ENV, "PRTE_LAUNCHED")
             "launcher.jl",
         ]
         # Start a PRTE session
-        prte = prrte_jll.prte() do prte
-            run(`$prte`, wait=false)
-        end
+        dvm = run(`$(prte()) --system-server`, wait=false)
         try
             for file in examples
                 example = realpath(joinpath(@__DIR__, "..", "examples", file))
@@ -40,7 +36,7 @@ if !haskey(ENV, "PRTE_LAUNCHED")
                 end
             end
         finally
-            kill(prte)
+            kill(dvm)
         end
     end
 
@@ -73,7 +69,7 @@ end
     str = PMIx.Value("hello", PMIx.API.PMIX_STRING)
     @test convert(String, str) == "hello"
 
-    ptr = PMIx.Value(C_NULL, PMIx.API.PMIX_STRING)
+    ptr = PMIx.Value(C_NULL, PMIx.API.PMIX_POINTER)
     @test convert(Ptr{Cvoid}, ptr) == C_NULL
     @test Base.unsafe_convert(Ptr{Cvoid}, ptr) == C_NULL
 end


### PR DESCRIPTION
- CompatHelper: add new compat entry for "Setfield" at version "0.8"
- CompatHelper: add new compat entry for "CEnum" at version "0.4" (#5)
- wrap headers for server and tool
- add suppost for string values
- init with info
- add launcher example
- slightly more useful error printing
